### PR TITLE
Standardize field name in UpdateUserNameRequest schema

### DIFF
--- a/openapi/components/schemas/UpdateUserNameRequest.yaml
+++ b/openapi/components/schemas/UpdateUserNameRequest.yaml
@@ -1,8 +1,8 @@
 type: object
 required:
-  - name
+  - user_name
 properties:
-  name:
+  user_name:
     type: string
     description: New user name
     example: "Jane Smith"


### PR DESCRIPTION
Change 'name' to 'user_name' for consistency with other user-related schemas.