### PR TITLE
Add app review preferences endpoint to OpenAPI specification

### DIFF
--- a/openapi/components/schemas/UpdateAppReviewRequest.yaml
+++ b/openapi/components/schemas/UpdateAppReviewRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - show_dialog
+properties:
+  show_dialog:
+    type: boolean
+    description: Whether to update the last dialog shown timestamp
+    example: true
+  app_review_status:
+    $ref: '../schemas/AppReviewStatus.yaml'
+    description: New app review status (optional)
+example:
+  show_dialog: true
+  app_review_status: "COMPLETED"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -15,6 +15,8 @@ paths:
     $ref: './paths/auth-users-uid.yaml'
   /auth/users:
     $ref: './paths/auth-users.yaml'
+  /auth/users/review-preferences:
+    $ref: './paths/auth-users-review-preferences.yaml'
   
   # Users
   /users/{userId}:

--- a/openapi/paths/auth-users-review-preferences.yaml
+++ b/openapi/paths/auth-users-review-preferences.yaml
@@ -1,0 +1,25 @@
+patch:
+  tags:
+    - Authentication
+  summary: Update user review preferences
+  description: Update user's app review dialog preferences and status
+  operationId: updateReviewPreferences
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/UpdateAppReviewRequest.yaml'
+  responses:
+    '200':
+      description: Review preferences successfully updated
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/AuthUserResponse.yaml'
+    '400':
+      $ref: '../components/responses/index.yaml#/BadRequest'
+    '404':
+      $ref: '../components/responses/index.yaml#/NotFound'
+    '500':
+      $ref: '../components/responses/index.yaml#/InternalServerError'


### PR DESCRIPTION
## Summary
- Add new `PATCH /auth-users/review-preferences` endpoint to OpenAPI specification
- Create `UpdateAppReviewRequest` schema for request validation
- Support `show_dialog` and `app_review_status` parameters

## Changes Made
### New Endpoint
- **Path**: `PATCH /auth-users/review-preferences`
- **Purpose**: Update user's app review dialog preferences and status
- **Authentication**: Requires Firebase JWT token
- **Request Body**: `UpdateAppReviewRequest` schema
- **Response**: Updated `AuthUserResponse` with review preferences

### New Schema
- **`UpdateAppReviewRequest`**:
  - `show_dialog`: boolean (required) - Updates last dialog shown timestamp
  - `app_review_status`: AppReviewStatus enum (optional) - Updates review status

## API Usage Example
```http
PATCH /auth-users/review-preferences
Authorization: Bearer <firebase_token>
Content-Type: application/json

{
  "show_dialog": true,
  "app_review_status": "COMPLETED"
}
```

## Response
```json
{
  "uid": "user123",
  "name": "John Doe",
  "email": "john@example.com",
  "last_app_review_dialog_shown_at": "2025-08-11T07:00:00.000Z",
  "app_review_status": "COMPLETED",
  ...
}
```

## Validation
- ✅ OpenAPI specification validates successfully
- ✅ Bundled distribution file updated
- ✅ Documentation generated without errors

## Related
This update corresponds to backend PR #138 in takafumi11/tateca-backend which implements the app review functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)